### PR TITLE
Fixed (?:) with AVX/SSE

### DIFF
--- a/share/src/bi/sse/math/avx_double.hpp
+++ b/share/src/bi/sse/math/avx_double.hpp
@@ -73,6 +73,8 @@ union avx_double {
   avx_double& operator=(const double& o) {
     packed = _mm256_set1_pd(o);
   }
+
+  operator bool() const { return (unpacked.a || unpacked.b); }
 };
 
 BI_FORCE_INLINE inline avx_double& operator+=(avx_double& o1,

--- a/share/src/bi/sse/math/avx_float.hpp
+++ b/share/src/bi/sse/math/avx_float.hpp
@@ -73,6 +73,8 @@ union avx_float {
   avx_float& operator=(const float& o) {
     packed = _mm256_set1_ps(o);
   }
+
+  operator bool() const { return (unpacked.a || unpacked.b); }
 };
 
 BI_FORCE_INLINE inline avx_float& operator+=(avx_float& o1,

--- a/share/src/bi/sse/math/sse_double.hpp
+++ b/share/src/bi/sse/math/sse_double.hpp
@@ -75,6 +75,8 @@ union sse_double {
     packed = _mm_set1_pd(o);
     return *this;
   }
+
+  operator bool() const { return (unpacked.a || unpacked.b); }
 };
 
 BI_FORCE_INLINE inline sse_double& operator+=(sse_double& o1,

--- a/share/src/bi/sse/math/sse_float.hpp
+++ b/share/src/bi/sse/math/sse_float.hpp
@@ -83,6 +83,10 @@ union sse_float {
     packed = _mm_set1_ps(o);
     return *this;
   }
+
+  operator bool() const { 
+    return (unpacked.a || unpacked.b || unpacked.c || unpacked.c); 
+  }
 };
 
 BI_FORCE_INLINE inline sse_float& operator+=(sse_float& o1,


### PR DESCRIPTION
This fixes a problem when using conditionals with `--enable-avx`. At the moment, this model
```
model conditional {
  state a
  state t_step

  sub initial {
    t_step <- 5
  }

  sub transition {
    a <- (t_now < t_step ? 0 : 1)
  }
}
```

fails when using

`libbi sample --model-file conditional.bi --enable-avx`

with

`could not convert 'bi::operator<(t_now__, t_step__)' from 'bi::avx_double' to 'bool'`

The attached fixes this by defining a `bool` operator.

On a side note, this also doesn't compile if `t_step` is a parameter, const or just a number because the corresponding types (`double`, `sse_float`) can't be compard to an `avx_double`. The fix works for me but I'm not particularly firm with this sort of vectorisation so it would be good to double-check if what I did makes any sense.