### PR TITLE
fix enable-cudafastmath option

### DIFF
--- a/lib/Bi/Builder.pm
+++ b/lib/Bi/Builder.pm
@@ -346,7 +346,7 @@ sub _configure {
     $options .= $self->{_assert} ? ' --enable-assert' : ' --disable-assert';
     $options .= $self->{_openmp} ? ' --enable-openmp' : ' --disable-openmp';
     $options .= $self->{_cuda} ? ' --enable-cuda' : ' --disable-cuda';
-    $options .= $self->{_cuda_fast_math} ? ' --enable-cuda-fast-math' : ' --disable-cuda-fast-math';
+    $options .= $self->{_cuda_fast_math} ? ' --enable-cudafastmath' : ' --disable-cudafastmath';
     $options .= $self->{_gpu_cache} ? ' --enable-gpucache' : ' --disable-gpucache';
     $options .= $self->{_sse} ? ' --enable-sse' : ' --disable-sse';
     $options .= $self->{_avx} ? ' --enable-avx' : ' --disable-avx';

--- a/share/configure.ac
+++ b/share/configure.ac
@@ -31,11 +31,11 @@ AC_ARG_ENABLE([cuda],
      esac],[cuda=false])
 
 AC_ARG_ENABLE([cudafastmath],
-     [  --enable-cuda-fast-math use fast-but-inaccurate math in CUDA],
+     [  --enable-cudafastmath use fast-but-inaccurate math in CUDA],
      [case "${enableval}" in
        yes) cudafastmath=true ;;
        no)  cudafastmath=false ;;
-       *) AC_MSG_ERROR([bad value ${enableval} for --enable-cuda-fast-math]) ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-cudafastmath]) ;;
      esac],[cudafastmath=false])
 
 AC_ARG_ENABLE([gpucache],


### PR DESCRIPTION
Fixes enable-cudafastmath which doesn't work at the moment because of discrepancies in variable names with/without hyphens.