### PR TITLE
Add cuda-arch option (defaulting to sm_30)

### DIFF
--- a/lib/Bi/Builder.pm
+++ b/lib/Bi/Builder.pm
@@ -78,6 +78,12 @@ For particle filters, enable ancestry caching in GPU memory. GPU memory is
 typically much more limited than main memory. If sufficient GPU memory is
 available this may give some performance improvement.
 
+=item C<--cuda-arch> (default sm_30)
+
+For particle filters, enable ancestry caching in GPU memory. GPU memory is
+typically much more limited than main memory. If sufficient GPU memory is
+available this may give some performance improvement.
+
 =item C<--enable-sse> (default off)
 
 Enable SSE code.
@@ -148,6 +154,7 @@ sub new {
         _cuda => 0,
         _cuda_fast_math => 0,
         _gpu_cache => 0,
+        _cuda_arch => 'sm_30',
         _sse => 0,
         _avx => 0,
         _mpi => 0,
@@ -177,6 +184,7 @@ sub new {
         'disable-cuda-fast-math' => sub { $self->{_cuda_fast_math} = 0 },
         'enable-gpu-cache' => sub { $self->{_gpu_cache} = 1 },
         'disable-gpu-cache' => sub { $self->{_gpu_cache} = 0 },
+        'cuda-arch=s' => sub { my ($opt_name, $opt_value) = @_; $self->{_cuda_arch} = $opt_value },
         'enable-sse' => sub { $self->{_sse} = 1 },
         'disable-sse' => sub { $self->{_sse} = 0 },
         'enable-avx' => sub { $self->{_avx} = 1 },
@@ -234,6 +242,7 @@ sub new {
     push(@builddir, 'extradebug') if $self->{_extra_debug};
     push(@builddir, 'diagnostics' . $self->{_diagnostics}) if $self->{_diagnostics};
     push(@builddir, 'gperftools') if $self->{_gperftools};
+    push(@builddir, $self->{_cuda_arch});
     
     $self->{_builddir} = File::Spec->catdir(".$name", join('_', @builddir));
     mkpath($self->{_builddir});
@@ -375,7 +384,7 @@ sub _configure {
         $self->_is_modified(File::Spec->catfile($builddir, 'configure')) ||
         !-e File::Spec->catfile($builddir, 'Makefile')) {
         
-        my $cmd = "./configure $options CXXFLAGS='$cxxflags' LINKFLAGS='$linkflags'";
+        my $cmd = "./configure $options CXXFLAGS='$cxxflags' LINKFLAGS='$linkflags' CUDA_ARCH='".($self->{_cuda_arch})."'";
         if ($self->{_verbose}) {
             print "$cmd\n";
         }

--- a/share/configure.ac
+++ b/share/configure.ac
@@ -318,6 +318,7 @@ AC_DEFINE_UNQUOTED([ENABLE_DIAGNOSTICS], [$diagnostics])
 
 # Variables for automake
 #AC_SUBST([NVCC], $NVCC)
+AC_SUBST([CUDA_ARCH], $CUDA_ARCH)
 
 # Checks for typedefs, structures, and compiler characteristics
 AC_HEADER_STDBOOL

--- a/share/src/bi/todo.hpp
+++ b/share/src/bi/todo.hpp
@@ -28,8 +28,6 @@
  *
  * @todo Exponential pdf, poisson pdf.
  *
- * @todo Add --cuda-arch flag to set sm_13, sm_20 or sm_30 etc.
- *
  * @todo Tidy up output file variable names, perhaps precede internal
  * variables with the program or schema name, e.g. simulate.time,
  * filter.logweight etc.

--- a/share/tt/build/Makefile.am.tt
+++ b/share/tt/build/Makefile.am.tt
@@ -26,7 +26,7 @@ AM_LDFLAGS = $(OPENMP_LDFLAGS)
 
 # CUDA files setup
 NVCPPFLAGS = $(AM_CPPFLAGS) $(CPPFLAGS) $(DEFS) -DBOOST_NOINLINE
-NVCXXFLAGS = -w -arch sm_20 -Xcompiler="$(AM_CXXFLAGS) $(CXXFLAGS)"
+NVCXXFLAGS = -w -arch $(CUDA_ARCH) -Xcompiler="$(AM_CXXFLAGS) $(CXXFLAGS)"
 LINK = $(CXXLINK) # force C++ linker for CUDA files
 
 # libraries


### PR DESCRIPTION
Introduces a cuda-arch option. The current default sm_20 is now deprecated.