### PR TITLE
Fix binomial distribution on GPUs

### DIFF
--- a/share/src/bi/cuda/random/RngGPU.cuh
+++ b/share/src/bi/cuda/random/RngGPU.cuh
@@ -190,7 +190,7 @@ inline T1 bi::RngGPU::binomial(T1 n, T2 p) {
     }
     else
       {
-        k += a;
+        k += floor(a);
         n = b - 1;
         p = (p - X) / (1 - X);
       }


### PR DESCRIPTION
Because LibBi isn't typed, the return variable k is real. The implementation is copied
from GSL's where k is an integer; here we need to call floor explicitly.