### PR TITLE
Remove runtime test from install time

### DIFF
--- a/t/010_cpu.t
+++ b/t/010_cpu.t
@@ -1,3 +1,0 @@
-use Test::More tests => 1;
-
-is(system('script/libbi sample @test.conf') >> 8, 0, 'CPU');


### PR DESCRIPTION
This is a runtime test which, arguably, should not be run at install time. It create problems whereby, for example, install can file on systems without OpenMP as there is no way to disable this at install time.

Besides, it creates problem for the homebrew install script which doesn't have access to the thrust headers at compile time.